### PR TITLE
Haiduong

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,98 +1,91 @@
 
-
 import 'package:chatapp/app.dart';
+import 'package:chatapp/screens/splash_screen.dart';
+import 'package:chatapp/widgets/avatar.dart';
 import 'package:chatapp/widgets/icon_buttons.dart';
-
-
-import 'package:firebase_auth/firebase_auth.dart' as firebase ;
+import 'package:firebase_auth/firebase_auth.dart' as firebase;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
 
+class ProfileScreen extends StatelessWidget {
+  static Route get route => MaterialPageRoute(
+    builder: (context) => const ProfileScreen(),
+  );
+  const ProfileScreen({Key? key}) : super(key: key);
 
-// class profile_screen extends StatelessWidget {
-//   // static Route get router => MaterialPageRoute(builder: builder)=> const profile_screen(),);
-//   const profile_screen({Key? key}): super(key: key);
-//
-//  @override
-//   Widget build(BuildContext) {
-//    var context;
-//    final user = context.currentUser;
-//    var arrow_back_ios_new;
-//    return Scaffold(
-//      appBar: AppBar(
-//        title: const Text('Profile'),
-//        leading: Center(
-//          child: IconBackground(
-//             icon: Icon.arrow_back_ios_new,
-//            onTap: () {
-//              Navigator.of(context).pop();
-//            },
-//          ),
-//        ),
-//    ),
-//  }
-//
-//
-//  }
-//    // body: Center(
-//    // child: Column(
-//    //   children: [
-//    //     Hero(
-//    // tag: 'hero-profile-picture',
-//    // child: Avatar.large(url: user?.image),
-//    // ),
-//    // Padding(
-//    //    padding: const EdgeInsets.all(8.0),
-//    //    child: Text(user?.name ?? 'No name'),
-//    // ),
-//    // const Divider(),
-//    // const _SignOutButton(),
-//    //      ],
-//
-//
-//
-//        }
-//
-//     abstract class _SignOutButton extends StatelessWidget{
-//         const _SignOutButton({
-//           Key? key,
-//         }): super(key: key);
-//         @override
-//       _SignOutButtonState createState()=> _SignOutButtonState();
-//     }
-//
-//     class _SignOutButtonState extends State<_SignOutButton>{
-//          bool _loading = false;
-//
-//          Future<void> _signOut() async {
-//            setState(() {
-//              _loading = true;
-//            });
-//
-//            try{
-//              await StreamChatCore.of(context).client.disconnectUser();
-//              await firebase.FirebaseAuth.instance.signOut();
-//
-//              var SplashScreen;
-//              Navigator.of(context).pushReplacement(SplashScreen.route);
-//            } on Exception catch (e, st) {
-//              logger.e('Could not sign out', e, st);
-//              setState(() {
-//                _loading = false;
-//              });
-//            }
-//          }
-//          @override
-//          Widget build(BuildContext context){
-//            return _loading
-//                ? const CircularProgressIndicator()
-//                : TextButton(
-//              onPressed: _signOut,
-//              child: const Text('Sign out'),
-//            );
-//          }
-//
-// }
-//
+  @override
+  Widget build(BuildContext context) {
+    final user = context.currentUser;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Profile'),
+        leading: Center(
+          child: IconBackground(
+            icon: Icons.arrow_back_ios_new,
+            onTap: () {
+              Navigator.of(context).pop();
+            },
+          ),
+        ),
+      ),
+      body: Center(
+        child: Column(
+          children: [
+            Hero(
+              tag: 'hero-profile-picture',
+              child: Avatar.large(url: user?.image),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Text(user?.name ?? 'No name'),
+            ),
+            const Divider(),
+            const _SignOutButton(),
+          ],
+        ),
+      ),
+    );
+  }
+}
 
+class _SignOutButton extends StatefulWidget {
+  const _SignOutButton({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  __SignOutButtonState createState() => __SignOutButtonState();
+}
+
+class __SignOutButtonState extends State<_SignOutButton> {
+  bool _loading = false;
+
+  Future<void> _signOut() async {
+    setState(() {
+      _loading = true;
+    });
+
+    try {
+      await StreamChatCore.of(context).client.disconnectUser();
+      await firebase.FirebaseAuth.instance.signOut();
+
+      Navigator.of(context).pushReplacement(SplashScreen.route);
+    } on Exception catch (e, st) {
+      logger.e('Could not sign out', e, st);
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _loading
+        ? const CircularProgressIndicator()
+        : TextButton(
+      onPressed: _signOut,
+      child: const Text('Sign out'),
+    );
+  }
+}

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:firebase_auth/firebase_auth.dart' as firebase;
+import 'package:flutter/material.dart';
+import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';
+
+import 'home_screen.dart';
+
+class SplashScreen extends StatefulWidget {
+  static Route get route => MaterialPageRoute(
+    builder: (context) => const SplashScreen(),
+  );
+  const SplashScreen({Key? key}) : super(key: key);
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  late final StreamSubscription<firebase.User?> listener;
+
+  @override
+  void initState() {
+    super.initState();
+    _handleAuthenticatedState();
+  }
+
+  Future<void> _handleAuthenticatedState() async {
+    final auth = firebase.FirebaseAuth.instance;
+    if (!mounted) {
+      return;
+    }
+    listener = auth.authStateChanges().listen((user) async {
+      if (user != null) {
+        // get Stream user token
+        final callable =
+        FirebaseFunctions.instance.httpsCallable('getStreamUserToken');
+
+        final results = await Future.wait([
+          callable(),
+          // delay to show loading indicator
+          Future.delayed(const Duration(milliseconds: 700)),
+        ]);
+
+        // connect Stream user
+        final client = StreamChatCore.of(context).client;
+        await client.connectUser(
+          User(id: user.uid),
+          results[0]!.data,
+        );
+
+        // authenticated
+        Navigator.of(context).pushReplacement(HomeScreen.route);
+      } else {
+        // delay to show loading indicator
+        await Future.delayed(const Duration(milliseconds: 700));
+        // not authenticated
+        var SignInScreen;
+        Navigator.of(context).pushReplacement(SignInScreen.route);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    listener.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
import 'package:chatapp/app.dart';
import 'package:chatapp/screens/splash_screen.dart';
import 'package:chatapp/widgets/avatar.dart';
import 'package:chatapp/widgets/icon_buttons.dart';
import 'package:firebase_auth/firebase_auth.dart' as firebase;
import 'package:flutter/cupertino.dart';
import 'package:flutter/material.dart';
import 'package:stream_chat_flutter_core/stream_chat_flutter_core.dart';

class ProfileScreen extends StatelessWidget {
  static Route get route => MaterialPageRoute(
    builder: (context) => const ProfileScreen(),
  );
  const ProfileScreen({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    final user = context.currentUser;
    return Scaffold(
      appBar: AppBar(
        title: const Text('Profile'),
        leading: Center(
          child: IconBackground(
            icon: Icons.arrow_back_ios_new,
            onTap: () {
              Navigator.of(context).pop();
            },
          ),
        ),
      ),
      body: Center(
        child: Column(
          children: [
            Hero(
              tag: 'hero-profile-picture',
              child: Avatar.large(url: user?.image),
            ),
            Padding(
              padding: const EdgeInsets.all(8.0),
              child: Text(user?.name ?? 'No name'),
            ),
            const Divider(),
            const _SignOutButton(),
          ],
        ),
      ),
    );
  }
}

class _SignOutButton extends StatefulWidget {
  const _SignOutButton({
    Key? key,
  }) : super(key: key);

  @override
  __SignOutButtonState createState() => __SignOutButtonState();
}

class __SignOutButtonState extends State<_SignOutButton> {
  bool _loading = false;

  Future<void> _signOut() async {
    setState(() {
      _loading = true;
    });

    try {
      await StreamChatCore.of(context).client.disconnectUser();
      await firebase.FirebaseAuth.instance.signOut();

      Navigator.of(context).pushReplacement(SplashScreen.route);
    } on Exception catch (e, st) {
      logger.e('Could not sign out', e, st);
      setState(() {
        _loading = false;
      });
    }
  }

  @override
  Widget build(BuildContext context) {
    return _loading
        ? const CircularProgressIndicator()
        : TextButton(
      onPressed: _signOut,
      child: const Text('Sign out'),
    );
  }
}